### PR TITLE
Redone LastFM

### DIFF
--- a/plugins/lastfm.moon
+++ b/plugins/lastfm.moon
@@ -26,11 +26,10 @@ recents = (msg,username) ->
 run = (msg,matches) ->
   if matches[1] == "lastfm" and matches[2]
     return recents msg,matches[2]
-  elseif matches[1] == "lastfm"
-    if msg.reply_to_message
+  elseif matches[1] == "lastfm" and msg.reply_to_message
       return recents msg,redis\get "bot:lastfm:user:#{msg.reply_to_message.from.id}"
-    else
-      return recents msg,redis\get "bot:lastfm:user:#{msg.from.id}"
+  else
+    return recents msg,redis\get "bot:lastfm:user:#{msg.from.id}"
 
 return {
   description: "Grab info from a LastFM profile"

--- a/plugins/lastfm.moon
+++ b/plugins/lastfm.moon
@@ -1,98 +1,50 @@
-run = (msg, matches) ->
-  username = ""
-  lastfm = redis\hgetall "bot:lastfm:users"
-  if msg.chat.type == "inline" and lastfm[tostring(msg.from.id)]
-    username = lastfm[tostring(msg.from.id)]
-
-  if string.match(msg.text, '^[!/]lastfm$') and msg.reply_to_message and lastfm[tostring(msg.reply_to_message.from.id)]
-    username = lastfm[tostring(msg.reply_to_message.from.id)]
-
-  if string.match(msg.text, "^[!/]lastfm$") and not msg.reply_to_message
-    if lastfm[tostring(msg.from.id)]
-      username = lastfm[tostring(msg.from.id)]
+recents = (msg,username) ->
+  if username == null
+      return "LastFM not linked\nUse `/me lastfm [username]` to set"
+  url = "http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=#{username}&api_key=#{config!.lastfm_api_key}&format=json"
+  response, code, headers = http.request url
+  if code ~= 200
+    return "There seems to be an error :(\nCode: #{code}"
+  if #response > 0
+    jdat = JSON.decode response
+    if jdat.error
+      return "Username not found :("
+    if jdat.recenttracks['@attr'].total == "0"
+      return "No recent tracks found :("
+    message = "[#{username}](http://www.last.fm/user/#{username}) "
+    if jdat.recenttracks.track[1]['@attr']
+        message ..= "is currently listening to: \n[#{jdat.recenttracks.track[1].name}\t-\t#{jdat.recenttracks.track[1].artist['#text']}](#{jdat.recenttracks.track[1].url})"
     else
-      return '*Please specify your last.fm username or set it with*`/lastfm set username`'
+        message ..= "last listened to:\n[#{jdat.recenttracks.track[1].name}\t-\t#{jdat.recenttracks.track[1].artist['#text']}](#{jdat.recenttracks.track[1].url})\n"
+    if msg.chat.type == "inline"
+        block = "[#{inline_article_block "What #{username} is listening to!", message, "Markdown" , true, "#{jdat.recenttracks.track[1].name} - #{jdat.recenttracks.track[1].artist['#text']}", "#{jdat.recenttracks.track[1].image[3]['#text']}"}]"
+        telegram!\sendInline msg.id, block
+        return
+    return message
 
-  if string.match msg.text, "^[!/]lastfm ([^%s]+)$"
-    if matches[1] == "rem"
-      redis\hdel "bot:lastfm:users", tostring(msg.from.id)
-      return '*Your last.fm username has been forgotten.*'
+
+run = (msg,matches) ->
+  if matches[1] == "lastfm" and matches[2]
+    return recents msg,matches[2]
+  elseif matches[1] == "lastfm"
+    if msg.reply_to_message
+      return recents msg,redis\get "bot:lastfm:user:#{msg.reply_to_message.from.id}"
     else
-      username = matches[1]
+      return recents msg,redis\get "bot:lastfm:user:#{msg.from.id}"
 
-  if string.match msg.text, "^[!/]lastfm (set) ([^%s]+)$"
-    if matches[1] == "set"
-      redis\hset "bot:lastfm:users", tostring(msg.from.id), matches[2]
-      return "*Your last.fm username has been set to* `#{matches[2]}`"
-    return
-  url = "http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&format=json&limit=1&api_key=#{config!.lastfm_api_key}&user="
-  if username == nil or username == ""
-    return '*Please specify your last.fm username or set it with*` /lastfm set username`'
-  url ..= URL.escape username
-
-  jstr, res = https.request url
-
-  if res ~= 200
-    if msg.chat.type == "inline"
-      return
-    return "Connection failed"
-
-  jdat = JSON.decode jstr
-
-  if jdat.error
-    if msg.chat.type == "inline"
-      return
-    return '*Please specify your last.fm username or set it with*` /lastfm set username`'
-
-  jdat = jdat.recenttracks.track[1] or jdat.recenttracks.track
-
-  unless jdat
-    if msg.chat.type == "inline"
-			return
-    return '_Iv\'e found nothing about this user_'
-  message = "*#{username}*"
-
-  if jdat['@attr'] and jdat['@attr'].nowplaying
-    message ..= ' *is currently listening to:*\n'
-  else
-    message ..= ' *last listened to:*\n'
-
-  title = jdat.name or '*Unknown*'
-  artist = '*Unknown*'
-  artist = jdat.artist['#text'] if jdat.artist
-
-  if msg.chat.type == "inline"
-    pic = "http://icons.iconarchive.com/icons/uiconstock/socialmedia/128/Lastfm-icon.png"
-    message = "#{message}`#{string.gsub(title,"%p", "-")}` *|* `#{string.gsub(artist,"%p", "-")}`"
-    block = "[#{inline_article_block "#{username} on Lastfm !", message, "Markdown" , true, "#{title} - #{artist}", "#{pic}"}]"
-    telegram!\sendInline msg.id, block
-    return
-
-  message = "#{message}`#{title}` *-* `#{artist}`"
-  return message
-
-description = "*Last.fm*"
-usage = [[
-`/lastfm`
-Returns what you are or were last listening to
-`/lastfm [username]`
-Returns what [username] is or was last listening to
-`/lastfm set [username]`
-Will set your username
-`/lastfm rem`
-Will remove your username
-]]
-patterns = {
-  "^[!/#]lastfm ([^%s]+)$"
-	"^[!/#]lastfm (set) ([^%s]+)$"
-	"^[!/#]lastfm$"
-	"###inline[!/]lastfm$"
-	"^[!/#]lf$"
-	"##inline[!/]lft$"
-}
 return {
-  :description
-  :usage
-  :patterns
+  description: "Grab info from a LastFM profile"
+  usage: "See what you're currently listening to or your last played song. This can also be used by replying to another user:
+`/lastfm`
+Allows you to specify a username for #{bot_first_name} to use:
+`/lastfm [username]`
+
+You can set your username with `/me lastfm [username]`."
+  patterns: {
+  "^[!/](lastfm) (.+)",
+  "^[!/]lastfm$",
+  "###inline[!/](lastfm) (.+)",
+  "###inline[!/]lastfm$"
+  }
   :run
 }

--- a/plugins/lastfm.moon
+++ b/plugins/lastfm.moon
@@ -22,12 +22,11 @@ recents = (msg,username) ->
         return
     return message
 
-
 run = (msg,matches) ->
   if matches[1] == "lastfm" and matches[2]
     return recents msg,matches[2]
-  elseif matches[1] == "lastfm" and msg.reply_to_message
-      return recents msg,redis\get "bot:lastfm:user:#{msg.reply_to_message.from.id}"
+  elseif msg.reply_to_message
+    return recents msg,redis\get "bot:lastfm:user:#{msg.reply_to_message.from.id}"
   else
     return recents msg,redis\get "bot:lastfm:user:#{msg.from.id}"
 

--- a/plugins/me.moon
+++ b/plugins/me.moon
@@ -9,6 +9,7 @@ parameters = {
 	["facebook"]: "[%s](https://www.facebook.com/%s)\n"
 	["reddit"]: "[%s](https://reddit.com/u/%s)\n"
 	["instagram"]: "[%s](https://www.instagram.com/%s)\n"
+	["lastfm"]: "[%s](http://www.lastfm.com/user/%s)\n"
 }
 patterns = {
 	"^[#!/](me)$"


### PR DESCRIPTION
Redoes LastFM for higher efficiency, /me integration, and various tweaks. For seamless integration with /me the redone plugin changes the way Jack stores lastfm entries. This python3 script will split up the set bot:lastfm:users to seperate entries: 
```
import redis

db = redis.StrictRedis(host="localhost", port=6379)

for a, b in db.hgetall("bot:lastfm:users").items():
    db.set("bot:lastfm:user:%s" % a.decode("utf-8"), b.decode("utf-8"))
```

Thanks +-+-+/@lina_inverse on Telegram for the script

![screenshot from 2016-03-27 10-18-34](https://cloud.githubusercontent.com/assets/14987096/14065782/5e468c16-f405-11e5-8802-efaa47c2c204.png)
![screenshot from 2016-03-27 10-05-25](https://cloud.githubusercontent.com/assets/14987096/14065783/6669bd1e-f405-11e5-8bf2-e61c5386505b.png)